### PR TITLE
Use getWeekInfo() instead of weekInfo

### DIFF
--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -73,7 +73,7 @@ const getWeekDays = (locale: string, weekStart: TWeekStart) => {
   return names
 }
 
-const firstDay = (new Intl.Locale(locale.value) as any)?.weekInfo?.firstDay || 1
+const firstDay = (new Intl.Locale(locale.value) as any)?.getWeekInfo()?.firstDay || 1
 const weekStart = (firstDay % 7) as TWeekStart
 
 const weekDays = getWeekDays(locale.value, weekStart)


### PR DESCRIPTION
weekInfo is changed to getWeekInfo() in https://tc39.es/proposal-intl-locale-info/

See tc39/proposal-intl-locale-info#67